### PR TITLE
Start with typescript-specific project root search

### DIFF
--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -76,12 +76,35 @@ function! tsuquyomi#config#tssargs()
   return join(args, ' ')
 endfunction
 
+" Search from cwd upward looking for first directory with package.json
+function! tsuquyomi#config#_path2project_directory_ts()
+  let parent = getcwd()
+
+  while 1
+    let path = parent . '/package.json'
+    if filereadable(path)
+      return parent
+    endif
+    let next = fnamemodify(parent, ':h')
+    if next == parent
+      return ''
+    endif
+    let parent = next
+  endwhile
+endfunction
+
 function! tsuquyomi#config#tsscmd()
   if s:tss_cmd !=# ''
     return s:tss_cmd
   endif
   if g:tsuquyomi_use_local_typescript != 0
-    let l:prj_dir = s:Prelude.path2project_directory(getcwd(), 1)
+    let l:prj_dir = tsuquyomi#config#_path2project_directory_ts()
+
+    if l:prj_dir == ''
+      " Fallback to generic project root search
+      let l:prj_dir = s:Prelude.path2project_directory(getcwd(), 1)
+    endif
+
     if l:prj_dir !=# ''
       let l:searched_tsserver_path = s:Filepath.join(l:prj_dir, 'node_modules/typescript/bin/tsserver')
       if filereadable(l:searched_tsserver_path)


### PR DESCRIPTION
The generic vital project root search will initially search for VCS
roots, and only after that fails look for project files (package.json
etc.). This implements an initial search for package.json, falling back
to the generic vital search. Fixes #173